### PR TITLE
ci: harden schema validation step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,9 @@ jobs:
           grep -q "^# " README.md || (echo "❌ README hat keinen Titel" && exit 1)
           echo "✅ README hat Titel"
 
-      - name: Validate JSON files in flows/
+      - name: Validate n8n flow schemas
         run: |
+          set -euo pipefail
           shopt -s nullglob
           for f in $(find flows -type f -name "*.json"); do
             echo "Prüfe $f ..."


### PR DESCRIPTION
## Summary
- ensure n8n flow schema validation step exits on any error

## Testing
- `yamllint -d '{extends: default, rules: {line-length: {max: 120}}}' .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_689c994c69ac8322a44ed7eb95a295b1