### PR TITLE
feat(profit): add OMNIKAI Profitability Engine (OPI) + weekly reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/profit_task.md
+++ b/.github/ISSUE_TEMPLATE/profit_task.md
@@ -1,0 +1,9 @@
+---
+name: Profit Task
+about: Maßnahme zur OPI-Steigerung
+labels: profit
+---
+**Hebel (Pricing/Retention/Distribution):**
+**Hypothese & Messgröße:**
+**ICE-Score (Impact/Confidence/Ease):**
+**Akzeptanzkriterium (OPI/Payback/GM):**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,4 @@
+---
 name: ci
 'on':
   push:
@@ -13,52 +14,72 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
-      - name: Install tools (jq)
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y jq
+        - name: Install tools (jq)
+          run: |
+            sudo apt-get update
+            sudo apt-get install -y jq
 
-      - name: Sanity Check – Ordnerstruktur
-        run: |
-          echo "✅ CI läuft"
-          test -d docs || (echo "❌ docs/ fehlt" && exit 1)
-          test -d prompts || echo "⚠️ prompts/ fehlt"
-          test -d flows || echo "⚠️ flows/ fehlt"
+        - name: Sanity Check – Ordnerstruktur
+          run: |
+            echo "✅ CI läuft"
+            test -d docs || (echo "❌ docs/ fehlt" && exit 1)
+            test -d prompts || echo "⚠️ prompts/ fehlt"
+            test -d flows || echo "⚠️ flows/ fehlt"
 
-      - name: Validate README format
-        run: |
-          grep -q "^# " README.md || (echo "❌ README hat keinen Titel" && exit 1)
-          echo "✅ README hat Titel"
+        - name: Validate README format
+          run: |
+            grep -q "^# " README.md || (echo "❌ README hat keinen Titel" && exit 1)
+            echo "✅ README hat Titel"
 
-      - name: Validate JSON files in flows/
-        run: |
-          shopt -s nullglob
-          for f in $(find flows -type f -name "*.json"); do
-            echo "Prüfe $f ..."
-            jq empty "$f" || exit 1
-          done
-          echo "✅ Alle JSON-Dateien gültig"
+        - name: Validate JSON files in flows/
+          run: |
+            shopt -s nullglob
+            for f in $(find flows -type f -name "*.json"); do
+              echo "Prüfe $f ..."
+              jq empty "$f" || exit 1
+            done
+            echo "✅ Alle JSON-Dateien gültig"
 
-      - name: Check Markdown files are non-empty
-        run: |
-          while IFS= read -r -d '' file; do
-            head -n 1 "$file" >/dev/null || (echo "❌ $file ist leer" && exit 1)
-          done < <(find . -name "*.md" -print0)
-          echo "✅ Markdown-Dateien OK"
+        - name: Check Markdown files are non-empty
+          run: |
+            while IFS= read -r -d '' file; do
+              head -n 1 "$file" >/dev/null || (echo "❌ $file ist leer" && exit 1)
+            done < <(find . -name "*.md" -print0)
+            echo "✅ Markdown-Dateien OK"
 
-  validate_sources:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+        - name: Install profit calc deps
+          run: python -m pip install --upgrade pip pandas numpy jinja2
 
-      - name: Ensure sources & schema exist
-        run: |
-          test -f datasources/sources.yaml || (echo "❌ datasources/sources.yaml fehlt" && exit 1)
-          test -f schemas/sources.schema.json || (echo "❌ schemas/sources.schema.json fehlt" && exit 1)
-          echo "✅ sources.yaml & Schema gefunden"
+        - name: Run profit calc
+          run: |
+            python tools/profit_calc.py \
+              --config profit/config.yaml \
+              --params profit/unit_economics.yaml \
+              --metrics data/metrics.csv \
+              --threshold tools/opindex_threshold.json \
+              --template dashboards/weekly_profit_report.md.gtpl \
+              --out /tmp/weekly_profit_report.md \
+              --json /tmp/weekly_profit_report.json
 
-      - name: Convert YAML to JSON
+    validate_sources:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v4
+          with:
+            submodules: recursive
+            fetch-depth: 0
+
+        - name: Ensure sources & schema exist
+          run: |
+            test -f datasources/sources.yaml || (echo "❌ datasources/sources.yaml fehlt" && exit 1)
+            test -f schemas/sources.schema.json || (echo "❌ schemas/sources.schema.json fehlt" && exit 1)
+            echo "✅ sources.yaml & Schema gefunden"
+
+        - name: Convert YAML to JSON
         run: |
           python -m pip install --upgrade pip
           python -m pip install pyyaml
@@ -77,20 +98,37 @@ jobs:
       - name: Validate schema with ajv
         run: ajv validate -s schemas/sources.schema.json -d /tmp/sources.json --spec=draft7
 
-      - name: Check listed files exist
-        run: |
-          python - <<'PY'
-          import os, json, sys
-          data = json.load(open('/tmp/sources.json','r', encoding='utf-8'))
-          missing = []
-          for s in data.get('sources', []):
-            p = (s or {}).get('path','')
-            fp = p.split('#', 1)[0]
-            if fp and not os.path.exists(fp):
-              missing.append(fp)
-          if missing:
-            print("❌ Fehlende Dateien:")
-            for m in missing: print(" -", m)
-            sys.exit(1)
-          print("✅ Alle referenzierten Dateien vorhanden.")
-          PY
+        - name: Check listed files exist
+          run: |
+            python - <<'PY'
+            import os, json, sys
+            data = json.load(open('/tmp/sources.json','r', encoding='utf-8'))
+            missing = []
+            for s in data.get('sources', []):
+              p = (s or {}).get('path','')
+              fp = p.split('#', 1)[0]
+              if fp and not os.path.exists(fp):
+                missing.append(fp)
+            if missing:
+              print("❌ Fehlende Dateien:")
+              for m in missing: print(" -", m)
+              sys.exit(1)
+            print("✅ Alle referenzierten Dateien vorhanden.")
+            PY
+
+  notify:
+    needs: [sanity, validate_sources]
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `CI failure - ${process.env.GITHUB_RUN_ID}`,
+              labels: ['ci-failure'],
+              body: `CI run failed: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${process.env.GITHUB_RUN_ID}`
+            })

--- a/.github/workflows/profit-weekly.yml
+++ b/.github/workflows/profit-weekly.yml
@@ -1,0 +1,72 @@
+---
+name: profit-weekly
+'on':
+  schedule: [{ cron: '0 6 * * *' }]
+  workflow_dispatch:
+jobs:
+  calc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - name: Ensure labels
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const req = ['profit','pricing','retention','distribution','priority:high'];
+            const existing = await github.paginate(github.rest.issues.listLabelsForRepo, {owner: context.repo.owner, repo: context.repo.repo});
+            const names = existing.map(l => l.name);
+            for (const l of req) {
+              if (!names.includes(l)) {
+                await github.rest.issues.createLabel({owner: context.repo.owner, repo: context.repo.repo, name: l});
+              }
+            }
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with: { python-version: '3.11' }
+      - name: Install deps
+        run: python -m pip install --upgrade pip pandas numpy jinja2
+      - name: Run profit calc
+        run: |
+          python tools/profit_calc.py \
+            --config profit/config.yaml \
+            --params profit/unit_economics.yaml \
+            --metrics data/metrics.csv \
+            --threshold tools/opindex_threshold.json \
+            --template dashboards/weekly_profit_report.md.gtpl \
+            --out dashboards/weekly_profit_report.md \
+            --json dashboards/weekly_profit_report.json
+      - name: Upload report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: weekly-profit-report
+          path: dashboards/weekly_profit_report.*
+      - name: Commit updated dashboard (if changed)
+        run: |
+          git config user.name "omnikai-bot"
+          git config user.email "bot@users.noreply.github.com"
+          git add dashboards/weekly_profit_report.*
+          git diff --cached --quiet || git commit -m "chore(profit): update weekly dashboard"
+      - name: Push
+        run: git push || true
+      - name: Create Issue if OPI below threshold
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const thr = JSON.parse(fs.readFileSync('tools/opindex_threshold.json','utf8'));
+            const rpt = JSON.parse(fs.readFileSync('dashboards/weekly_profit_report.json','utf8'));
+            if (rpt.OPI < thr.min_opi || rpt.gross_margin < thr.min_gm || rpt.Payback > thr.max_payback_months) {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: `Profitability action required – OPI ${rpt.OPI.toFixed(2)}`,
+                labels: ['profit','priority:high'],
+                body: `Auto‑Alert:\n\n- OPI: ${rpt.OPI}\n- Gross Margin: ${rpt.gross_margin}\n- Payback (months): ${rpt.Payback}\n\nTop 3 Empfehlungen:\n${rpt.Recos.join('\n')}`
+              });
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.env
+.env.*
+*.secret
+secrets/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![CI](https://github.com/xXNewbiXx/OMNIKAI-Aufbau/actions/workflows/ci.yml/badge.svg)
+[![Weekly Profit Report](https://github.com/xXNewbiXx/OMNIKAI-Aufbau/actions/workflows/profit-weekly.yml/badge.svg)](dashboards/weekly_profit_report.md)
 
 # OMNIKAI – Aufbau (Blueprint)
 Robustes, modular skalierbares Multi‑Agenten‑System. Steuer‑KI: Claude. Unterstützend: Gemini (Deep Research), Grok (Trend/Red‑Team). Orchestrierung über zwei gekoppelte n8n‑Flows (*Think* → Struktur, *Execute* → Umsetzung).

--- a/dashboards/weekly_profit_report.json
+++ b/dashboards/weekly_profit_report.json
@@ -1,0 +1,27 @@
+{
+  "date": "2025-08-14",
+  "OPI": 1.1588571428571428,
+  "LTV": 133.7142857142857,
+  "CAC": 45.0,
+  "Payback": 4.807692307692308,
+  "gross_margin": 0.78,
+  "Velocity": 0.5,
+  "visitors": 100,
+  "signups": 20,
+  "trials": 5,
+  "paid_users": 2,
+  "conv_vs": 20.0,
+  "conv_st": 25.0,
+  "conv_tp": 40.0,
+  "NetRev": 137.20000000000002,
+  "Recos": [
+    "Price/Packaging"
+  ],
+  "sparkline": "▁",
+  "Experiments_shipped_last_7d": 0,
+  "thresholds": {
+    "min_opi": 1.2,
+    "min_gm": 0.6,
+    "max_payback_months": 4
+  }
+}

--- a/dashboards/weekly_profit_report.md
+++ b/dashboards/weekly_profit_report.md
@@ -1,0 +1,26 @@
+# Weekly Profit Report
+
+Date: 2025-08-14
+
+| Metric | Value |
+|-------|-------|
+| OPI | 1.16 |
+| LTV | 133.71 |
+| CAC | 45.0 |
+| Payback (months) | 4.81 |
+| Gross Margin | 0.78 |
+| Velocity | 0.5 |
+
+## Funnel
+Visitors→Signups→Trials→Paid
+- Visitors: 100
+- Signups: 20 (20.0%)
+- Trials: 5 (25.0%)
+- Paid Users: 2 (40.0%)
+
+## Recommendations
+- Price/Packaging
+
+
+## Sparkline
+▁

--- a/dashboards/weekly_profit_report.md.gtpl
+++ b/dashboards/weekly_profit_report.md.gtpl
@@ -1,0 +1,26 @@
+# Weekly Profit Report
+
+Date: {{ date }}
+
+| Metric | Value |
+|-------|-------|
+| OPI | {{ OPI | round(2) }} |
+| LTV | {{ LTV | round(2) }} |
+| CAC | {{ CAC | round(2) }} |
+| Payback (months) | {{ Payback | round(2) }} |
+| Gross Margin | {{ gross_margin | round(2) }} |
+| Velocity | {{ Velocity | round(2) }} |
+
+## Funnel
+Visitors→Signups→Trials→Paid
+- Visitors: {{ visitors }}
+- Signups: {{ signups }} ({{ conv_vs | round(2) }}%)
+- Trials: {{ trials }} ({{ conv_st | round(2) }}%)
+- Paid Users: {{ paid_users }} ({{ conv_tp | round(2) }}%)
+
+## Recommendations
+{% for r in Recos %}- {{ r }}
+{% endfor %}
+
+## Sparkline
+{{ sparkline }}

--- a/data/metrics.csv
+++ b/data/metrics.csv
@@ -1,0 +1,2 @@
+date,visitors,signups,trials,paid_users,mrr,marketing_spend,refunds,support_tickets
+2025-08-14,100,20,5,2,240,50,0,1

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,3 +11,14 @@ flowchart LR
   C --> D[Flow 2: EXECUTE]
   D --> E[Outputs: Artefakte/Reports/Commits]
   E -->|Feedback| B
+```
+
+## Profitability Engine (OPI)
+Die wöchentlichen Auswertungen liegen unter `dashboards/`. Lokal lässt sich der Report mit
+
+```bash
+python tools/profit_calc.py --config profit/config.yaml --params profit/unit_economics.yaml \
+  --metrics data/metrics.csv --threshold tools/opindex_threshold.json \
+  --template dashboards/weekly_profit_report.md.gtpl --out dashboards/weekly_profit_report.md \
+  --json dashboards/weekly_profit_report.json
+```

--- a/profit/README.md
+++ b/profit/README.md
@@ -1,0 +1,9 @@
+# Profit Module
+
+Dieses Modul bündelt Konfiguration, Experimente und Playbooks zur Messung und Steuerung der Profitabilität. Kernkennzahl ist der **OMNIKAI Profit Index (OPI)**, berechnet aus:
+
+- **LTV** = ARPU_month × Gross Margin × (1 / Churn)
+- **Payback (Monate)** = CAC / (ARPU_month × Gross Margin)
+- **OPI** = (LTV / CAC) × Gross Margin × Velocity
+
+Weitere Details in `tools/profit_calc.py` und den wöchentlichen Reports unter `dashboards/`.

--- a/profit/config.yaml
+++ b/profit/config.yaml
@@ -1,0 +1,6 @@
+currency: EUR
+vat_rate: 0.19
+cost_centers:
+  - marketing
+  - support
+  - infrastructure

--- a/profit/experiments_backlog.md
+++ b/profit/experiments_backlog.md
@@ -1,0 +1,15 @@
+# Experiments Backlog
+
+Jedes Experiment wird als YAML-Block notiert:
+
+```yaml
+- title: Experimentname
+  lever: pricing|retention|distribution
+  hypothesis: Beschreibung
+  metric: Kennzahl
+  impact: 0-10
+  confidence: 0-10
+  ease: 0-10
+  status: todo|done
+  date: YYYY-MM-DD
+```

--- a/profit/playbooks/distribution_loops.md
+++ b/profit/playbooks/distribution_loops.md
@@ -1,0 +1,7 @@
+# Distribution Loops
+
+1. **Referrals** – Nutzer laden andere ein.
+2. **User Generated Content** – Inhalte teilen Reichweite.
+3. **Partnerships** – Kooperationen mit passenden Plattformen.
+4. **Affiliates** – Provisionierte Empfehlungen.
+5. **Bundles** – Produktbündel mit Mehrwert.

--- a/profit/playbooks/pricing_tests.md
+++ b/profit/playbooks/pricing_tests.md
@@ -1,0 +1,9 @@
+# Pricing Tests
+
+Dreistufige Value Ladder:
+
+1. **Basic** – niedriger Einstiegspreis, Kernfeatures.
+2. **Pro** – mittleres Paket mit erweiterten Funktionen.
+3. **Enterprise** – höchste Stufe, individuelle Konditionen.
+
+A/B-Tests prüfen Zahlungsbereitschaft und Paketgrenzen.

--- a/profit/playbooks/retention_loops.md
+++ b/profit/playbooks/retention_loops.md
@@ -1,0 +1,7 @@
+# Retention Loops
+
+1. **Onboarding Guides** – geführter Einstieg.
+2. **Usage Nudges** – Erinnerungen bei Inaktivität.
+3. **Winback Kampagnen** – gezieltes Reaktivieren churnender Nutzer.
+4. **Community Events** – regelmäßige Austauschformate.
+5. **Customer Success Calls** – proaktive Betreuung.

--- a/profit/unit_economics.yaml
+++ b/profit/unit_economics.yaml
@@ -1,0 +1,6 @@
+cac:           45.0        # Customer Acquisition Cost (EUR)
+arpu_month:    12.0        # Average Revenue / User / Monat
+gross_margin:  0.78        # Deckungsbeitrag I
+churn_month:   0.07        # monatliche Abwanderung
+trial_to_paid: 0.22        # Konversionsrate Test->Zahlung
+payback_target_months: 3   # Ziel CAC-Payback

--- a/tools/opindex_threshold.json
+++ b/tools/opindex_threshold.json
@@ -1,0 +1,1 @@
+{ "min_opi": 1.2, "min_gm": 0.6, "max_payback_months": 4 }

--- a/tools/profit_calc.py
+++ b/tools/profit_calc.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import re
+from datetime import datetime, timedelta
+
+import pandas as pd
+import yaml
+from jinja2 import Template
+
+
+def ensure_metrics(path):
+    if not os.path.exists(path):
+        today = datetime.today().date().isoformat()
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write('date,visitors,signups,trials,paid_users,mrr,marketing_spend,refunds,support_tickets\n')
+            f.write(f"{today},0,0,0,0,0,0,0,0\n")
+    return pd.read_csv(path, parse_dates=['date'])
+
+
+def count_experiments(path):
+    if not os.path.exists(path):
+        return 0
+    text = open(path, 'r', encoding='utf-8').read()
+    blocks = re.findall(r'-\s*title:.*?(?=\n-\s*title:|\Z)', text, re.S)
+    count = 0
+    cutoff = datetime.today().date() - timedelta(days=7)
+    for b in blocks:
+        status = re.search(r'status:\s*(\w+)', b)
+        date_m = re.search(r'date:\s*(\d{4}-\d{2}-\d{2})', b)
+        if status and status.group(1) == 'done' and date_m:
+            d = datetime.fromisoformat(date_m.group(1)).date()
+            if d >= cutoff:
+                count += 1
+    return count
+
+
+def sparkline(values):
+    ticks = '▁▂▃▄▅▆▇█'
+    if not values:
+        return ''
+    mn, mx = min(values), max(values)
+    if mx == mn:
+        return ticks[0] * len(values)
+    scale = len(ticks) - 1
+    return ''.join(ticks[int((v - mn) / (mx - mn) * scale)] for v in values)
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('--config', required=True)
+    p.add_argument('--params', required=True)
+    p.add_argument('--metrics', required=True)
+    p.add_argument('--threshold', required=True)
+    p.add_argument('--template', required=True)
+    p.add_argument('--out', required=True)
+    p.add_argument('--json', required=True)
+    args = p.parse_args()
+
+    cfg = yaml.safe_load(open(args.config, encoding='utf-8'))
+    params = yaml.safe_load(open(args.params, encoding='utf-8'))
+    thr = json.load(open(args.threshold, encoding='utf-8'))
+
+    df = ensure_metrics(args.metrics).sort_values('date')
+    latest = df.iloc[-1]
+    prev = df.iloc[-2] if len(df) > 1 else None
+
+    visitors = latest['visitors']
+    signups = latest['signups']
+    trials = latest['trials']
+    paid = latest['paid_users']
+    mrr = latest['mrr']
+
+    conv_vs = (signups / visitors * 100) if visitors else 0
+    conv_st = (trials / signups * 100) if signups else 0
+    conv_tp = (paid / trials * 100) if trials else 0
+
+    variable_costs = latest['marketing_spend'] + latest['refunds']
+    gross_margin = params['gross_margin']
+    netrev = mrr * gross_margin - variable_costs
+
+    if prev is not None and prev['paid_users'] > 0:
+        churn = max((prev['paid_users'] - paid) / prev['paid_users'], 0)
+    else:
+        churn = params['churn_month']
+
+    LTV = params['arpu_month'] * params['gross_margin'] * (1 / params['churn_month'])
+    Payback = params['cac'] / (params['arpu_month'] * params['gross_margin'])
+
+    experiments = count_experiments('profit/experiments_backlog.md')
+    Velocity = experiments / 3.0
+    Velocity = max(0.5, min(2.0, Velocity))
+
+    OPI = (LTV / params['cac']) * params['gross_margin'] * Velocity
+
+    recos = []
+    if Payback > params.get('payback_target_months', 0):
+        recos.append('Price/Packaging')
+    if (conv_tp / 100) < params.get('trial_to_paid', 1):
+        recos.append('Activation/Onboarding')
+    if churn > 0.08:
+        recos.append('Retention/Winback')
+    recos = recos[:3]
+
+    spark = sparkline(df['mrr'].tail(8).tolist())
+
+    summary = {
+        'date': latest['date'].date().isoformat(),
+        'OPI': float(OPI),
+        'LTV': float(LTV),
+        'CAC': float(params['cac']),
+        'Payback': float(Payback),
+        'gross_margin': float(gross_margin),
+        'Velocity': float(Velocity),
+        'visitors': int(visitors),
+        'signups': int(signups),
+        'trials': int(trials),
+        'paid_users': int(paid),
+        'conv_vs': float(conv_vs),
+        'conv_st': float(conv_st),
+        'conv_tp': float(conv_tp),
+        'NetRev': float(netrev),
+        'Recos': recos,
+        'sparkline': spark,
+        'Experiments_shipped_last_7d': int(experiments),
+        'thresholds': thr,
+    }
+
+    tpl = Template(open(args.template, encoding='utf-8').read())
+    with open(args.out, 'w', encoding='utf-8') as f:
+        f.write(tpl.render(**summary))
+    with open(args.json, 'w', encoding='utf-8') as f:
+        json.dump(summary, f, ensure_ascii=False, indent=2)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add Profitability Engine with config, unit economics, backlog and playbooks
- generate weekly profit report via script and scheduled workflow
- expose OPI metrics in docs and README

## Testing
- `python tools/profit_calc.py --config profit/config.yaml --params profit/unit_economics.yaml --metrics data/metrics.csv --threshold tools/opindex_threshold.json --template dashboards/weekly_profit_report.md.gtpl --out dashboards/weekly_profit_report.md --json dashboards/weekly_profit_report.json`


------
https://chatgpt.com/codex/tasks/task_e_689dc6d24a5083228a8ab0fdc067ea64