### PR TITLE
ci/checkout-submodules: add PAT for submodule checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,19 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   sanity:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: recursive
           fetch-depth: 0
+          submodules: recursive
+          token: ${{ secrets.GH_PAT_SUBMODULES }}
+          persist-credentials: false
 
       - name: Install tools (jq)
         run: |
@@ -58,8 +63,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: recursive
           fetch-depth: 0
+          submodules: recursive
+          token: ${{ secrets.GH_PAT_SUBMODULES }}
+          persist-credentials: false
 
       - name: Ensure sources & schema exist
         # yamllint disable rule:line-length

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "flows/n8n/black-project"]
-	path = flows/n8n/black-project
-	url = https://github.com/xXNewbiXx/omnikai-black-project.git
+        path = flows/n8n/black-project
+        url = https://github.com/xXNewbiXx/omnikai-black-project.git
+        branch = main
 [submodule "flows/n8n/n8n-core"]
 	path = flows/n8n/n8n-core
 	url = https://github.com/n8n-io/n8n.git


### PR DESCRIPTION
## Summary
- ensure `actions/checkout` fetches submodules using `GH_PAT_SUBMODULES`
- declare `main` branch for `flows/n8n/black-project` submodule

## Testing
- `for f in $(find flows -type f -name "*.json"); do echo Checking $f; jq empty "$f" || exit 1; done`
- `python -m pip install --quiet pyyaml`
- `python - <<'PY'
import json, yaml, sys
with open('datasources/sources.yaml','r', encoding='utf-8') as f:
    data = yaml.safe_load(f) or {}
with open('/tmp/sources.json','w', encoding='utf-8') as f:
    json.dump(data, f, ensure_ascii=False)
print('OK: /tmp/sources.json geschrieben', file=sys.stderr)
PY`
- `npm i -g ajv-cli@5 >/tmp/ajv.log && tail -n 20 /tmp/ajv.log`
- `ajv validate -s schemas/sources.schema.json -d /tmp/sources.json --spec=draft7`
- `python - <<'PY'
import os, json, sys
with open('/tmp/sources.json','r', encoding='utf-8') as f:
    data = json.load(f)
missing = []
for s in data.get('sources', []):
    p = (s or {}).get('path','')
    fp = p.split('#', 1)[0]
    if fp and not os.path.exists(fp):
        missing.append(fp)
if missing:
    print('❌ Fehlende Dateien:')
    for m in missing:
        print(' -', m)
    sys.exit(1)
print('✅ Alle referenzierten Dateien vorhanden.')
PY`

## Rollback
- revert commit `fix(ci): checkout submodules with PAT`

------
https://chatgpt.com/codex/tasks/task_e_689deced25bc83229c2ec4f0339e62c0