### PR TITLE
chore(templates): add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug Report
+about: Report a reproducible issue
+title: "[Bug]: "
+labels: ["bug"]
+assignees: []
+---
+
+## Description
+A clear description of the bug.
+
+## Steps to Reproduce
+1. ...
+2. ...
+
+## Expected Behavior
+Describe what you expected to happen.
+
+## Environment
+- Version: 
+- OS: 
+
+## Additional Context
+Add any other context, screenshots, or logs about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: "[Feature]: "
+labels: ["enhancement"]
+assignees: []
+---
+
+## Summary
+Provide a clear and concise description of the feature.
+
+## Motivation
+Explain why this feature would be useful.
+
+## Additional Context
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+# Summary
+Provide a brief overview of the changes.
+
+## Checklist
+- [ ] CI pipeline is green
+- [ ] Submodules are synced (`git submodule update --init --recursive` && `bash scripts/update_submodules.sh`)
+- [ ] Rollback steps documented
+
+## Rollback Steps
+Describe how to undo this change if needed.


### PR DESCRIPTION
## Summary
- add pull request template with CI, submodule sync, and rollback checklist
- add bug report and feature request issue templates using GitHub front matter

## Checklist
- [x] CI green
- [ ] Auto-Issue-Step active
- [ ] Submodule/Vendor present
- [ ] Prompts copied
- [ ] Docs+Security+CODEOWNERS+Ignore updated


------
https://chatgpt.com/codex/tasks/task_e_689df0db628c8322991ca812c6db72d4