### PR TITLE
chore(templates): add contributing guide and community templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,21 @@
+---
+name: Bug report
+about: Report a problem to help us improve
+title: "[BUG] "
+labels: bug
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. 
+2. 
+3. 
+
+**Expected behavior**
+What you expected to happen.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,15 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FEATURE] "
+labels: enhancement
+---
+
+**Summary**
+A clear and concise description of the feature request.
+
+**Motivation**
+Why is this feature needed?
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+## Summary
+Describe the changes in this pull request.
+
+## Checklist
+- [ ] CI is green
+- [ ] `git submodule update --init --recursive` run
+- [ ] `bash scripts/update_submodules.sh` run
+- [ ] Documentation updated

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.env
+.env.*
+*.secret
+secrets/

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+/external/claude-flow/ @xXNewbiXx
+/prompts/claude/claude-flow/ @xXNewbiXx

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Contributing
+
+## Branches
+Use `type/scope` naming, e.g. `feat/api` or `fix/docs`.
+
+## Commits
+Follow [Conventional Commits](https://www.conventionalcommits.org/).
+
+## Pull Requests
+Use the [PR template](.github/PULL_REQUEST_TEMPLATE.md) and ensure:
+
+- CI is green
+- Submodules updated: `git submodule update --init --recursive` and `bash scripts/update_submodules.sh`
+- Documentation updated
+
+## Templates
+Issue templates live in [`.github/ISSUE_TEMPLATE`](.github/ISSUE_TEMPLATE).
+
+## External Modules
+External modules such as `claude-flow` are tracked as git submodules. To update them:
+
+1. `git submodule update --init --recursive`
+2. `bash scripts/update_submodules.sh`
+3. Commit the result in a pull request for review.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+## Reporting a Vulnerability
+Please open a security advisory or contact the maintainers if you discover a vulnerability.
+
+## External Modules
+Updates to external modules are only accepted via pull request and require review.


### PR DESCRIPTION
## Summary
- add CONTRIBUTING guide with branch naming, Conventional Commits, PR checklist
- provide issue and PR templates
- add security policy, code owners, and gitignore defaults

## Checklist
- [ ] CI green
- [ ] Auto-issue step active
- [ ] Submodule/Vendor vorhanden
- [ ] Prompts kopiert
- [x] Docs+Security+CODEOWNERS+Ignore aktualisiert

------
https://chatgpt.com/codex/tasks/task_e_689df57655ac83228e3670cb906cd2d2