### PR TITLE
docs: add branch protection guidelines

### DIFF
--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -1,0 +1,10 @@
+# Branch Protection
+
+To configure repository protections:
+
+1. Enable "Workflow permissions: Read and write" in **Settings → Actions → General**.
+2. Protect the `main` branch with:
+   - Required status checks: `ci` and `black-guard`.
+   - At least one approving review (self-review allowed).
+   - Enforce rules for administrators.
+   - Enable auto-merge.


### PR DESCRIPTION
## Summary
- document how to configure branch protection and workflow permissions

## Manual steps
1. Enable "Workflow permissions: Read and write" in Settings → Actions → General.
2. Protect `main` with required checks `ci` and `black-guard`, require one review (self-review allowed), enforce administrators and enable auto-merge.

## Checklist
- [ ] CI green


------
https://chatgpt.com/codex/tasks/task_e_689e455d7c008322b2e4d06538094c16